### PR TITLE
Fixed Berksfile dependency example in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Use this cookbook if you plan to deploy a Rails application that uses Postgresql
 Include this cookbook in your `Berksfile`.
 
 ````
-cookbook 'libpq-dev', git: 'aerogami-cookbooks/libpq-dev'
+cookbook 'libpq-dev', github: 'aerogami-cookbooks/libpq-dev'
 ````
 
 Install the cookbook.
@@ -18,6 +18,13 @@ berks install
 
 Add to your chef kitchen and use as desired.
 
+Example usage within your cookbook:
+
+````
+include_recipe 'libpq-dev'
+````
+
+
 # Requirements
 
 This cookbook requires `apt`.
@@ -27,3 +34,5 @@ This cookbook requires `apt`.
 Mohamad El-Husseini
 
 www.aerogami.com.br
+
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # libpq-dev cookbook
 
-Use this cookbook if you plan to deploy a Rails application that uses Postgresql. This library is required for the `pg` gem to work whether or not Postgresql is installed.
+Use this cookbook if you plan to deploy a Rails application that uses Postgresql. This library is required for the `pg` gem to work whether or not Postgresql is installed. Note: This cookbook currently only supports APT-based distributions, eg. Ubuntu.
 
 # Usage
 


### PR DESCRIPTION
Berksfile dependency does not work with "git:" keyword, but with "github:" keyword.
Additionally, added a usage example and a limitation note.
