### PR TITLE
Added support for Amazon Linux and Mac OS X

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ Berksfile.lock
 .*.sw[a-z]
 *.un~
 /cookbooks
+.idea
 
 # Bundler
 Gemfile.lock

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # libpq-dev cookbook
 
-Use this cookbook if you plan to deploy a Rails application that uses Postgresql. This library is required for the `pg` gem to work whether or not Postgresql is installed. Note: This cookbook currently only supports APT-based distributions, eg. Ubuntu.
+Use this cookbook if you plan to deploy a Rails application that uses PostgreSQL.
+This library is required for the `pg` gem to work whether or not Postgresql is installed.
+Note: This cookbook currently supports APT-based distributions (eg. Ubuntu), the Amazon platform, and potentially Mac OS X.
 
 # Usage
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,9 @@ version          '0.1.0'
 
 recipe 'libpq-dev', 'Installs libpq-dev'
 
-supports 'Ubuntu'
+supports 'ubuntu'
+supports 'amazon'       # tested with Amazon Linux 2014.09 ('= 2014.09')
+supports 'mac_os_x'     # tested with Mac OS X Yosemite v10.10.1 ('~> 10.10.0')
+
+suggests 'homebrew'
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -7,11 +7,23 @@
 # Apache 2.0
 #
 
-bash 'update apt-get' do
-  user 'root'
-  code <<-EOC
-    apt-get update
-  EOC
-end
+case node['platform_family']
+  when 'debian'
+    bash 'update apt-get' do
+      user 'root'
+      code <<-EOC
+        apt-get update
+      EOC
+    end
+end #case
 
-package 'libpq-dev'
+
+package 'libpq-dev' do
+  package_name value_for_platform_family(
+      'debian'   => 'libpq-dev',
+      'rhel'     => 'postgresql-devel',
+      'mac_os_x' => 'postgresql',
+  )
+end #package
+
+

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -21,7 +21,7 @@ end #case
 package 'libpq-dev' do
   package_name value_for_platform_family(
       'debian'   => 'libpq-dev',
-      'rhel'     => 'postgresql-devel',
+      'rhel'     => 'postgresql8-devel',   # generic: postgresql-devel  (works with warning)
       'mac_os_x' => 'postgresql',
   )
 end #package


### PR DESCRIPTION
The changes have been tested with the following platform-versions:
Amazon Linux 2014.09
Mac OS X Yosemite v10.10.1
Ubuntu v14.04
